### PR TITLE
Fix arc sweep flag and improve package publishing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2026 James Porter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ This repo contains a `llm.md` file that can be used to provide context to a Larg
 
 ## Updates
 
+### 0.6.2
+
+- Independent `sweep` flag for arcs (previously tied to `largeArc`), so all four arc variants between two points can be drawn
+- `ellipse` now draws four clean quarter arcs instead of overlapping half-ellipses (better for pen plotting; visually identical)
+- Fixed the published package for Node ESM consumers: proper `exports` map, module-type markers, and file extensions in relative imports
+- Added LICENSE (MIT) and README to the published package
+- Documentation improvements (arcs/ellipse API reference and JSDoc)
+
+### 0.6.1
+
+- Type safety improvements in `Path` and generics, improved path cloning
+- Replaced ESLint with oxlint (type-aware) and added CI workflows for tests and linting
+
+### 0.6.0
+
+- API reference page and more APIs
+
 ### 0.5.1
 
 - Minor typo fixes and updated documentation on using with AIs.

--- a/llm.md
+++ b/llm.md
@@ -16,6 +16,8 @@ This is the main class of the library. It is responsible for creating the SVG el
 
 The `Path` class is used to define the geometry of an SVG shape. You can create a new path using `s.path()` or more specific methods like `s.strokedPath()`. Once you have a path object, you can use methods like `moveTo()`, `lineTo()`, `arcTo()`, and `curveTo()` to define its shape.
 
+`arcTo(point, config?)` accepts an optional config: `rX`/`rY` (radii, defaulting to the x/y distance to the target), `xAxisRotation` (degrees), `largeArc` (take the longer way around the ellipse) and `sweep` (draw in the clockwise direction; defaults to the value of `largeArc`, so set it explicitly to get the mirrored pair of arcs).
+
 ### `Attributes` Class
 
 The `Attributes` class is used to set the visual properties of a path, such as its stroke, fill, and opacity. You can create a new `Attributes` object using `s.A` and then chain methods like `stroke()`, `fill()`, and `opacity()` to configure the desired attributes.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "solandra-svg",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "engines": {
     "node": ">=25.9.0"

--- a/pre-publish.ts
+++ b/pre-publish.ts
@@ -12,14 +12,58 @@ const packageTemplate = {
   name: "solandra-svg",
   author: "James Porter <james@amimetic.co.uk>",
   version,
+  description:
+    "A declarative, fluent, concise, type-safe SVG drawing library for generative art and plotting",
+  keywords: [
+    "svg",
+    "generative-art",
+    "creative-coding",
+    "plotter",
+    "drawing",
+    "graphics",
+  ],
+  repository: {
+    type: "git",
+    url: "git+https://github.com/jamesporter/solandra-svg.git",
+  },
+  homepage: "https://solandra-svg.netlify.app/",
+  license: "MIT",
   main: "./cjs/index.js",
   module: "./esm/index.js",
-  license: "MIT",
-  dependencies: {},
   types: "./esm/index.d.ts",
+  exports: {
+    ".": {
+      import: {
+        types: "./esm/index.d.ts",
+        default: "./esm/index.js",
+      },
+      require: {
+        types: "./cjs/index.d.ts",
+        default: "./cjs/index.js",
+      },
+    },
+  },
+  sideEffects: false,
+  dependencies: {},
 }
 
 fs.writeFileSync(
   path.join("package", "package.json"),
   JSON.stringify(packageTemplate, null, 2)
 )
+
+// Mark each build directory with its module type so Node resolves both
+// formats correctly (the published root package.json has no "type" field).
+fs.mkdirSync(path.join("package", "esm"))
+fs.writeFileSync(
+  path.join("package", "esm", "package.json"),
+  JSON.stringify({ type: "module" }, null, 2)
+)
+fs.mkdirSync(path.join("package", "cjs"))
+fs.writeFileSync(
+  path.join("package", "cjs", "package.json"),
+  JSON.stringify({ type: "commonjs" }, null, 2)
+)
+
+fs.copyFileSync("README.md", path.join("package", "README.md"))
+fs.copyFileSync("LICENSE", path.join("package", "LICENSE"))

--- a/src/lib/__tests__/path.test.ts
+++ b/src/lib/__tests__/path.test.ts
@@ -110,6 +110,31 @@ describe("Path", () => {
         },
       })
     })
+
+    it("should default sweep to match largeArc (same-ellipse arcs)", () => {
+      const path = new Path(Attributes.empty)
+      path
+        .moveTo([0, 0])
+        .arcTo([1, 1])
+        .arcTo([0, 0], { largeArc: true })
+      expect(path.segments[1]).toMatchObject({
+        config: { largeArc: false, sweep: false },
+      })
+      expect(path.segments[2]).toMatchObject({
+        config: { largeArc: true, sweep: true },
+      })
+    })
+
+    it("should allow the sweep flag to be set independently", () => {
+      const path = new Path(Attributes.empty)
+      path
+        .moveTo([0, 0])
+        .arcTo([1, 1], { sweep: true })
+        .arcTo([0, 0], { largeArc: true, sweep: false })
+      expect(path.string(0)).toMatchInlineSnapshot(
+        `"<path d="M 0 0 A 1 1 0 0 1 1 1 A 1 1 0 1 0 0 0" />"`,
+      )
+    })
   })
 
   describe("rect", () => {
@@ -212,6 +237,45 @@ describe("Path", () => {
       }
       expect(moveSegment.to[0]).toBeCloseTo(0.1, 5) // at[0] + width/2
       expect(moveSegment.to[1]).toBeCloseTo(0, 5) // at[1]
+    })
+
+    it("should draw quarter arcs through the extreme points, ending at the start", () => {
+      const path = new Path(Attributes.empty)
+      path.ellipse([0.5, 0.5], 0.4, 0.2)
+      const points = path.segments.map((s) => (s as { to: [number, number] }).to)
+      const expected: [number, number][] = [
+        [0.5, 0.4], // top (start)
+        [0.3, 0.5], // left
+        [0.5, 0.6], // bottom
+        [0.7, 0.5], // right
+        [0.5, 0.4], // back to top
+      ]
+      expect(points).toHaveLength(expected.length)
+      points.forEach((p, i) => {
+        expect(p[0]).toBeCloseTo(expected[i][0], 10)
+        expect(p[1]).toBeCloseTo(expected[i][1], 10)
+      })
+    })
+  })
+
+  describe("spiral", () => {
+    it("should create a move followed by n line segments", () => {
+      const path = new Path(Attributes.empty)
+      path.spiral([0.5, 0.5], 0.1, 20)
+      expect(path.segments).toHaveLength(21)
+      expect(path.segments[0].kind).toBe("move")
+      expect(path.segments.filter((s) => s.kind === "line")).toHaveLength(20)
+    })
+
+    it("should move outwards from the center", () => {
+      const path = new Path(Attributes.empty)
+      path.spiral([0, 0], 0.1, 50)
+      const first = path.segments[0] as { to: [number, number] }
+      const last = path.segments[path.segments.length - 1] as {
+        to: [number, number]
+      }
+      const dist = ([x, y]: [number, number]) => Math.hypot(x, y)
+      expect(dist(last.to)).toBeGreaterThan(dist(first.to))
     })
   })
 

--- a/src/lib/attributes.ts
+++ b/src/lib/attributes.ts
@@ -1,6 +1,6 @@
-import { Transform } from "./transforms"
-import { hslToRgb } from "./util/colorCalcs"
-import { Point2D } from "./util/types"
+import { Transform } from "./transforms.js"
+import { hslToRgb } from "./util/colorCalcs.js"
+import { Point2D } from "./util/types.js"
 
 /**
  * Fluent builder for SVG presentation attributes and inline styles.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,16 +4,16 @@
  * @packageDocumentation
  */
 
-export * from "./svg"
-export * from "./attributes"
-export * from "./transforms"
-export * from "./path"
+export * from "./svg.js"
+export * from "./attributes.js"
+export * from "./transforms.js"
+export * from "./path.js"
 
-export * from "./util/noise"
+export * from "./util/noise.js"
 /** Vector/point math utilities (add, subtract, rotate, scale, etc.) */
-export { default as v } from "./util/vectors"
+export { default as v } from "./util/vectors.js"
 /** Collection operations (pairWise, tripleWise, zip2, sum, arrayOf) */
-export { default as c } from "./util/collectionOps"
-export * from "./util/util"
+export { default as c } from "./util/collectionOps.js"
+export * from "./util/util.js"
 
-export * from "./util/types"
+export * from "./util/types.js"

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -1,8 +1,8 @@
-import { Point2D, CurveConfig, ArcConfig } from "./util/types"
-import { convertToSVGCubicSpec } from "./util/curveCalcs"
-import { Attributes } from "./attributes"
-import { v } from "."
-import { indent } from "./util/internalUtil"
+import { Point2D, CurveConfig, ArcConfig } from "./util/types.js"
+import { convertToSVGCubicSpec } from "./util/curveCalcs.js"
+import { Attributes } from "./attributes.js"
+import v from "./util/vectors.js"
+import { indent } from "./util/internalUtil.js"
 
 /**
  * A discriminated union representing a single segment in an SVG path.
@@ -78,11 +78,11 @@ function segmentToString(segment: PathSegment, previous?: Point2D): string {
       })
     case "arc":
       const {
-        config: { rX, rY, largeArc, xAxisRotation },
+        config: { rX, rY, largeArc, sweep, xAxisRotation },
         to,
       } = segment
       return `A ${rX} ${rY} ${xAxisRotation} ${largeArc ? 1 : 0} ${
-        largeArc ? 1 : 0
+        sweep ? 1 : 0
       } ${to[0]} ${to[1]}`
   }
 }
@@ -168,8 +168,11 @@ export class Path {
    * If radii are not specified, they default to the absolute x/y distance between
    * the current position and the target point.
    *
+   * The `sweep` flag defaults to the value of `largeArc`, which keeps the short
+   * and long arcs on the same ellipse; set it explicitly to draw the mirrored arcs.
+   *
    * @param point - The target position
-   * @param config - Optional arc configuration (radii, rotation, large arc flag)
+   * @param config - Optional arc configuration (radii, rotation, large arc and sweep flags)
    * @returns `this` for chaining
    */
   arcTo(point: Point2D, config: ArcConfig = {}): Path {
@@ -185,6 +188,7 @@ export class Path {
       rX = Math.abs(point[0] - previous[0]),
       rY = Math.abs(point[1] - previous[1]),
       largeArc = false,
+      sweep = largeArc,
       xAxisRotation = 0,
     } = config
 
@@ -196,6 +200,7 @@ export class Path {
         rY: rY,
         xAxisRotation,
         largeArc,
+        sweep,
       },
     })
 
@@ -286,26 +291,35 @@ export class Path {
     const rY = height / 2
 
     // draw from top, seems most natural, like a clock?
-    this.segments.push({ kind: "move", to: [cX, cY - height / 2] })
+    // four quarter arcs counterclockwise: top, left, bottom, right, back to top
+    this.segments.push({ kind: "move", to: [cX, cY - rY] })
     for (let i = 0; i < 4; i++) {
-      this.arcTo(
-        [
-          cX + rX * Math.cos(Math.PI * (i + 1)),
-          cY + rY * Math.sin(Math.PI * (i + 1)),
-        ],
-        { rX, rY },
-      )
+      const angle = ((i + 2) * Math.PI) / 2
+      this.arcTo([cX + rX * Math.cos(angle), cY - rY * Math.sin(angle)], {
+        rX,
+        rY,
+      })
     }
     return this
   }
 
+  /**
+   * Draws a spiral of `n` straight segments of (roughly) equal length around a point.
+   *
+   * @param at - The center of the spiral
+   * @param l - The length of each segment (and the starting radius)
+   * @param n - The number of segments
+   * @param angle - The starting angle in radians (default `0`)
+   * @param rate - How quickly the radius grows per radian turned (default `0.005`)
+   * @returns `this` for chaining
+   */
   spiral(
     at: Point2D,
     l: number,
     n: number,
     angle: number = 0,
     rate: number = 0.005,
-  ) {
+  ): Path {
     let a = angle
     let r = l
 

--- a/src/lib/svg.ts
+++ b/src/lib/svg.ts
@@ -1,9 +1,9 @@
-import { Point2D, Vector2D } from "./util/types"
-import { Path } from "./path"
-import { Attributes } from "./attributes"
-import { indent } from "./util/internalUtil"
-import { RNG } from "./rng"
-import { Transform } from "./transforms"
+import { Point2D, Vector2D } from "./util/types.js"
+import { Path } from "./path.js"
+import { Attributes } from "./attributes.js"
+import { indent } from "./util/internalUtil.js"
+import { RNG } from "./rng.js"
+import { Transform } from "./transforms.js"
 
 /**
  * An SVG `<g>` group element that can contain nested {@link Path} and {@link Group} children.
@@ -241,6 +241,14 @@ ${this.elements
     return path
   }
 
+  /**
+   * Creates a new filled {@link Path} with sensible defaults for solid shapes.
+   *
+   * Defaults: black fill, full opacity, no stroke.
+   *
+   * @param configureAttributes - Optional callback to further customise the attributes
+   * @returns The new filled path
+   */
   filledPath(configureAttributes?: (attributes: Attributes) => void): Path {
     const attr = Attributes.filled.fill(0, 0, 0).fillOpacity(1)
     configureAttributes?.(attr)
@@ -648,7 +656,7 @@ ${this.elements
    * @param callback - Called with each value in the range
    */
   range(
-    config: { from: number; to: number; n: number; inclusive?: boolean },
+    config: { from?: number; to?: number; n: number; inclusive?: boolean },
     callback: (n: number) => void,
   ) {
     const { from = 0, to = 1, n, inclusive = true } = config

--- a/src/lib/transforms.ts
+++ b/src/lib/transforms.ts
@@ -1,4 +1,4 @@
-import { Point2D } from "./util/types"
+import { Point2D } from "./util/types.js"
 
 /**
  * Fluent builder for SVG transform attribute strings.

--- a/src/lib/util/colorCalcs.ts
+++ b/src/lib/util/colorCalcs.ts
@@ -1,4 +1,4 @@
-import { arrayOf } from "./collectionOps"
+import { arrayOf } from "./collectionOps.js"
 
 /**
  * Converts a hue component to an RGB channel value.

--- a/src/lib/util/curveCalcs.ts
+++ b/src/lib/util/curveCalcs.ts
@@ -1,5 +1,5 @@
-import { Point2D, CurveConfig } from "./types"
-import { default as v } from "./vectors"
+import { Point2D, CurveConfig } from "./types.js"
+import { default as v } from "./vectors.js"
 
 /**
  * Converts a curve configuration into an SVG cubic bezier path command string.

--- a/src/lib/util/internalUtil.ts
+++ b/src/lib/util/internalUtil.ts
@@ -1,4 +1,4 @@
-import { arrayOf } from "./collectionOps"
+import { arrayOf } from "./collectionOps.js"
 
 /**
  * Indents a line of text with spaces (2 spaces per indentation level).

--- a/src/lib/util/noise.ts
+++ b/src/lib/util/noise.ts
@@ -1,4 +1,4 @@
-import { dot } from "./vectors";
+import { dot } from "./vectors.js";
 
 /**
  * 2D Perlin noise implementation.

--- a/src/lib/util/types.ts
+++ b/src/lib/util/types.ts
@@ -41,4 +41,14 @@ export type ArcConfig = {
   xAxisRotation?: number
   /** Whether the arc should take the longer path (arc greater than pi). */
   largeArc?: boolean
+  /**
+   * The SVG sweep flag: if `true` the arc is drawn in the positive-angle
+   * (clockwise, as displayed) direction; if `false` in the negative-angle
+   * (counterclockwise) direction.
+   *
+   * Defaults to the value of `largeArc`, which keeps the short and long arcs
+   * on the same ellipse (and matches this library's historical output).
+   * Set it explicitly to reach the mirrored pair of arcs.
+   */
+  sweep?: boolean
 }

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -1,4 +1,4 @@
-import { Point2D } from "./types"
+import { Point2D } from "./types.js"
 
 /**
  * Clamps a number to a given range.

--- a/src/lib/util/vectors.ts
+++ b/src/lib/util/vectors.ts
@@ -1,4 +1,4 @@
-import { Point2D } from "./types"
+import { Point2D } from "./types.js"
 
 /**
  * Adds two 2D points component-wise.

--- a/src/pages/APIReference.tsx
+++ b/src/pages/APIReference.tsx
@@ -46,6 +46,55 @@ const svg = new SolandraSvg(width, height, 1)`}
         }}
         className="bg-zinc-100"
       />
+      <h3>Ellipse</h3>
+      <Source code={`s.strokedPath().ellipse(s.meta.center, 0.5, 0.3)`} />
+      <SVGSketch
+        width={320}
+        height={320}
+        sketch={(s) => {
+          s.strokedPath().ellipse(s.meta.center, 0.5, 0.3)
+        }}
+        className="bg-zinc-100"
+      />
+      <h3>Arcs</h3>
+      <p>
+        Draw elliptical arcs between points. By default the radii are taken
+        from the distance between the points; use{" "}
+        <span className="font-mono">largeArc</span> to take the longer way
+        around the same ellipse and <span className="font-mono">sweep</span> to
+        draw in the opposite (mirrored) direction.
+      </p>
+      <Source
+        code={`const a: Point2D = [0.35, 0.6]
+const b: Point2D = [0.65, 0.4]
+s.strokedPath((at) => at.stroke(0, 90, 50)).moveTo(a).arcTo(b)
+s.strokedPath((at) => at.stroke(120, 90, 40)).moveTo(a).arcTo(b, { sweep: true })
+s.strokedPath((at) => at.stroke(210, 90, 50)).moveTo(a).arcTo(b, { largeArc: true })
+s.strokedPath((at) => at.stroke(280, 90, 50))
+  .moveTo(a)
+  .arcTo(b, { largeArc: true, sweep: false })`}
+      />
+      <SVGSketch
+        width={320}
+        height={320}
+        sketch={(s) => {
+          const a: Point2D = [0.35, 0.6]
+          const b: Point2D = [0.65, 0.4]
+          s.strokedPath((at) => at.stroke(0, 90, 50))
+            .moveTo(a)
+            .arcTo(b)
+          s.strokedPath((at) => at.stroke(120, 90, 40))
+            .moveTo(a)
+            .arcTo(b, { sweep: true })
+          s.strokedPath((at) => at.stroke(210, 90, 50))
+            .moveTo(a)
+            .arcTo(b, { largeArc: true })
+          s.strokedPath((at) => at.stroke(280, 90, 50))
+            .moveTo(a)
+            .arcTo(b, { largeArc: true, sweep: false })
+        }}
+        className="bg-zinc-100"
+      />
       <h3>Spiral</h3>
       <Source code={`s.strokedPath().spiral(s.meta.center, 0.1, 50)`} />
       <SVGSketch

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,15 +1,17 @@
 {
   "compilerOptions": {
     "target": "ES2016",
-    "module": "CommonJS",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0",
+    "rootDir": "./src/lib",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "./package/cjs",
     "lib": ["DOM", "ESNext"],
     "declaration": true,
-    "skipLibCheck": true,
-    "moduleResolution": "node"
+    "skipLibCheck": true
   },
   "include": ["./src/lib/index.ts"]
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -2,14 +2,15 @@
   "compilerOptions": {
     "target": "ES2016",
     "module": "esnext",
+    "moduleResolution": "bundler",
+    "rootDir": "./src/lib",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "./package/esm",
     "lib": ["DOM", "ESNext"],
     "declaration": true,
-    "skipLibCheck": true,
-    "moduleResolution": "node"
+    "skipLibCheck": true
   },
   "include": ["./src/lib/index.ts"]
 }


### PR DESCRIPTION
## Summary
This release fixes the SVG arc sweep flag to be independently configurable (previously tied to `largeArc`), improves the ellipse drawing algorithm, and fixes the published package for proper Node ESM support.

## Key Changes

### Arc Sweep Flag Independence
- Added independent `sweep` flag to `ArcConfig` type that defaults to `largeArc` value for backward compatibility
- Updated `Path.arcTo()` to properly handle the sweep flag separately from largeArc
- Fixed arc segment string generation to use sweep flag instead of incorrectly duplicating largeArc
- This enables drawing all four arc variants between two points (previously only two were accessible)
- Added comprehensive tests for sweep flag behavior and independence

### Ellipse Drawing Improvements
- Refactored `Path.ellipse()` to draw four clean quarter-arc segments instead of overlapping half-ellipses
- Better for pen plotting applications while maintaining identical visual output
- Added test verifying correct endpoint positions for quarter arcs

### Package Publishing Fixes
- Added proper `exports` map in package.json for ESM/CJS dual support
- Created module-type marker files (`esm/package.json` and `cjs/package.json`) for correct Node resolution
- Updated all relative imports to use `.js` file extensions (required for ESM)
- Updated TypeScript configs with proper `moduleResolution` and `rootDir` settings
- Added LICENSE (MIT) and README to published package
- Enhanced package.json metadata (description, keywords, repository, homepage)

### Documentation
- Added API reference examples for ellipse and arcs in APIReference.tsx
- Improved JSDoc comments for `arcTo()`, `ellipse()`, `spiral()`, and `filledPath()`
- Updated README with 0.6.2 release notes

### Type Safety
- Made `from` and `to` parameters optional in `SolandraSvg.range()` config with sensible defaults
- Added comprehensive JSDoc for arc configuration options

## Implementation Details
- The sweep flag defaults to largeArc to maintain backward compatibility with existing code
- Ellipse now uses consistent angle calculations for all four quarter arcs
- All internal imports updated to use explicit `.js` extensions for ESM compatibility

https://claude.ai/code/session_01Fwo5SQmNdmQ9vodgYPmwD9