### PR TITLE
Reduce duplication in lib and cover the untested surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `aroundCircle` now emits its first point at the top of the circle (angle
   `-π/2`), matching the documented starting angle. Previously every point was
   rotated forward by one step, so the top point was emitted last.
+- Hues outside the `0`-`360` range (e.g. `h + 20` on a hue near `350`) now wrap
+  correctly instead of collapsing to a flat colour once they were more than one
+  turn out. Saturation and lightness outside their documented ranges are clamped,
+  so `fill`/`stroke` can no longer emit an invalid hex colour.
+- A curve that follows a `close` (which has no destination point of its own) now
+  raises a clear error instead of failing inside the curve maths.
 
 ### Changed
 
@@ -20,6 +26,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `engines` field and is unaffected.
 - CI now reads the Node version from `.nvmrc` (set to `22`) as a single source
   of truth.
+- Internal refactoring to remove duplication, with no change to rendered output:
+  SVG serialisation, data URI generation, grid iteration order, the
+  horizontal/vertical strip helpers, path insertion, and the `cutPath`/
+  `creasePath` presets are each now defined once. The shared iteration callback
+  signature is exported as `RegionCallback`.
+- `Path` no longer casts segments to an unchecked helper type to read their end
+  point, and its shape helpers (`rect`, `regularPolygon`, `ellipse`, `spiral`)
+  build on its own fluent methods rather than pushing raw segments.
+- `fillOklch` and `strokeOklch` now declare `alpha` as optional, matching the
+  behaviour they already had.
 
 ### Added
 
@@ -29,6 +45,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   guarding against broken publishes.
 - Tests for `aroundCircle`, `gaussian`, `poisson`, `proportionately`, and
   `uniformRandomInt`, which were previously untested.
+- Test coverage for the layout iteration utilities (`forTiling`, `forMargin`,
+  `forHorizontal`, `forVertical`, `forGrid`, `build`, `withRandomOrder`, `range`,
+  `times`, `downFrom`, `doProportion`, `inDrawing`), the remaining randomness
+  helpers (`sample`, `samples`, `shuffle`, `perturb`, `randomPoint`,
+  `randomPolarity`, `randomAngle`, `uniformGridPoint`), the SVG output variants
+  (`imageSrc`, the Inkscape-ready renderings, `groupWithId`, `clonePath`, and the
+  path presets), and `perlin2`, which had no tests at all.
 
 ## [0.6.2]
 

--- a/src/lib/__tests__/noise.test.ts
+++ b/src/lib/__tests__/noise.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import { perlin2 } from "../util/noise"
+
+describe("perlin2", () => {
+  it("is zero at lattice points", () => {
+    for (let x = -3; x <= 3; x++) {
+      for (let y = -3; y <= 3; y++) {
+        expect(perlin2(x, y)).toBeCloseTo(0, 12)
+      }
+    }
+  })
+
+  it("is deterministic for the same coordinates", () => {
+    expect(perlin2(0.3, 1.7)).toBe(perlin2(0.3, 1.7))
+    expect(perlin2(-12.25, 4.5)).toBe(perlin2(-12.25, 4.5))
+  })
+
+  it("stays within the documented [-1, 1] range", () => {
+    const limit = 1
+    for (let i = 0; i < 2000; i++) {
+      const x = (i % 71) * 0.137
+      const y = (i % 53) * 0.219
+      const n = perlin2(x, y)
+      expect(n).toBeGreaterThanOrEqual(-limit)
+      expect(n).toBeLessThanOrEqual(limit)
+    }
+  })
+
+  it("produces varied, non-constant output", () => {
+    const values = new Set<number>()
+    for (let i = 0; i < 200; i++) {
+      values.add(perlin2(i * 0.13, i * 0.29))
+    }
+    expect(values.size).toBeGreaterThan(150)
+  })
+
+  it("is continuous: nearby inputs give nearby outputs", () => {
+    for (let i = 0; i < 100; i++) {
+      const x = i * 0.31
+      const y = i * 0.17
+      const delta = Math.abs(perlin2(x, y) - perlin2(x + 0.001, y + 0.001))
+      expect(delta).toBeLessThan(0.02)
+    }
+  })
+
+  it("tiles with a period of 256 on both axes", () => {
+    expect(perlin2(0.5, 0.5)).toBeCloseTo(perlin2(256.5, 0.5), 12)
+    expect(perlin2(0.5, 0.5)).toBeCloseTo(perlin2(0.5, 256.5), 12)
+    expect(perlin2(3.25, 7.75)).toBeCloseTo(perlin2(259.25, 263.75), 12)
+  })
+
+  it("takes both positive and negative values", () => {
+    let min = Infinity
+    let max = -Infinity
+    for (let i = 0; i < 500; i++) {
+      const n = perlin2(i * 0.11, i * 0.07)
+      min = Math.min(min, n)
+      max = Math.max(max, n)
+    }
+    expect(min).toBeLessThan(-0.1)
+    expect(max).toBeGreaterThan(0.1)
+  })
+})

--- a/src/lib/__tests__/path.test.ts
+++ b/src/lib/__tests__/path.test.ts
@@ -113,10 +113,7 @@ describe("Path", () => {
 
     it("should default sweep to match largeArc (same-ellipse arcs)", () => {
       const path = new Path(Attributes.empty)
-      path
-        .moveTo([0, 0])
-        .arcTo([1, 1])
-        .arcTo([0, 0], { largeArc: true })
+      path.moveTo([0, 0]).arcTo([1, 1]).arcTo([0, 0], { largeArc: true })
       expect(path.segments[1]).toMatchObject({
         config: { largeArc: false, sweep: false },
       })
@@ -242,7 +239,9 @@ describe("Path", () => {
     it("should draw quarter arcs through the extreme points, ending at the start", () => {
       const path = new Path(Attributes.empty)
       path.ellipse([0.5, 0.5], 0.4, 0.2)
-      const points = path.segments.map((s) => (s as { to: [number, number] }).to)
+      const points = path.segments.map(
+        (s) => (s as { to: [number, number] }).to,
+      )
       const expected: [number, number][] = [
         [0.5, 0.4], // top (start)
         [0.3, 0.5], // left
@@ -389,6 +388,39 @@ describe("Path", () => {
         attrs.stroke(180, 50, 50)
       })
       expect(path.string(0)).toMatch(/stroke/)
+    })
+  })
+
+  describe("segments without a destination point", () => {
+    it("should reject an arcTo with no preceding segment", () => {
+      const path = new Path(Attributes.empty)
+      expect(() => path.arcTo([1, 1])).toThrow(
+        "arcTo requires a previous segment with a destination point",
+      )
+    })
+
+    it("should reject an arcTo directly after a close", () => {
+      const path = new Path(Attributes.empty)
+      path.moveTo([0, 0]).lineTo([1, 1]).close()
+      expect(() => path.arcTo([0.5, 0.5])).toThrow(
+        "arcTo requires a previous segment with a destination point",
+      )
+    })
+
+    it("should report a clear error for a curve after a close", () => {
+      const path = new Path(Attributes.empty)
+      path.moveTo([0, 0]).lineTo([1, 1]).close().curveTo([0.5, 0.5])
+      expect(() => path.string(0)).toThrow(
+        "A curve must follow a segment with a destination point",
+      )
+    })
+
+    it("should leave close segments alone when smoothing", () => {
+      const path = new Path(Attributes.empty)
+      path.moveTo([0, 0]).lineTo([1, 0]).close().lineTo([1, 1]).lineTo([0, 1])
+
+      expect(() => path.chaikin(1)).not.toThrow()
+      expect(path.segments.some((s) => s.kind === "close")).toBe(true)
     })
   })
 })

--- a/src/lib/__tests__/svgLayout.test.ts
+++ b/src/lib/__tests__/svgLayout.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from "vitest"
+import { SolandraSvg } from "../svg"
+import { Point2D, Vector2D } from "../util/types"
+
+type Region = {
+  point: Point2D
+  delta: Vector2D
+  center: Point2D
+  i: number
+}
+
+const collectRegions = (
+  run: (cb: (p: Point2D, d: Vector2D, c: Point2D, i: number) => void) => void,
+): Region[] => {
+  const regions: Region[] = []
+  run((point, delta, center, i) => regions.push({ point, delta, center, i }))
+  return regions
+}
+
+describe("forTiling", () => {
+  it("splits a square drawing into n x n cells, column first by default", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const regions = collectRegions((cb) => s.forTiling({ n: 2 }, cb))
+
+    expect(regions.map((r) => r.point)).toEqual([
+      [0, 0],
+      [0, 0.5],
+      [0.5, 0],
+      [0.5, 0.5],
+    ])
+    expect(regions.map((r) => r.i)).toEqual([0, 1, 2, 3])
+    for (const r of regions) {
+      expect(r.delta).toEqual([0.5, 0.5])
+      expect(r.center).toEqual([r.point[0] + 0.25, r.point[1] + 0.25])
+    }
+  })
+
+  it("walks across rows when order is rowFirst", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const regions = collectRegions((cb) =>
+      s.forTiling({ n: 2, order: "rowFirst" }, cb),
+    )
+
+    expect(regions.map((r) => r.point)).toEqual([
+      [0, 0],
+      [0.5, 0],
+      [0, 0.5],
+      [0.5, 0.5],
+    ])
+  })
+
+  it("produces square cells for type: square on a non-square drawing", () => {
+    const s = new SolandraSvg(200, 100, 1) // aspectRatio 2
+    const regions = collectRegions((cb) =>
+      s.forTiling({ n: 4, type: "square" }, cb),
+    )
+
+    // 4 columns x 2 rows of 0.25 square cells fills the 1 x 0.5 drawing.
+    expect(regions).toHaveLength(8)
+    for (const r of regions) {
+      expect(r.delta[0]).toBeCloseTo(r.delta[1], 10)
+      expect(r.delta[0]).toBeCloseTo(0.25, 10)
+    }
+  })
+
+  it("centres the tiling vertically when square cells do not fill the height", () => {
+    const s = new SolandraSvg(100, 300, 1) // aspectRatio 1/3, height 3
+    const regions = collectRegions((cb) =>
+      s.forTiling({ n: 2, type: "square" }, cb),
+    )
+
+    // nY = floor(2 * 3) = 6 rows of 0.5 => height 3, exactly filling; offset 0
+    expect(regions[0].point[1]).toBeCloseTo(0, 10)
+    expect(regions).toHaveLength(12)
+  })
+
+  it("insets the tiling by the margin", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const regions = collectRegions((cb) =>
+      s.forTiling({ n: 1, margin: 0.1 }, cb),
+    )
+
+    expect(regions).toHaveLength(1)
+    expect(regions[0].point[0]).toBeCloseTo(0.1, 10)
+    expect(regions[0].point[1]).toBeCloseTo(0.1, 10)
+    expect(regions[0].delta[0]).toBeCloseTo(0.8, 10)
+    expect(regions[0].delta[1]).toBeCloseTo(0.8, 10)
+  })
+})
+
+describe("forMargin", () => {
+  it("is a single region inset by the margin", () => {
+    const s = new SolandraSvg(200, 100, 1)
+    const regions = collectRegions((cb) => s.forMargin(0.05, cb))
+
+    expect(regions).toHaveLength(1)
+    expect(regions[0].point[0]).toBeCloseTo(0.05, 10)
+    expect(regions[0].point[1]).toBeCloseTo(0.05, 10)
+    expect(regions[0].delta[0]).toBeCloseTo(0.9, 10)
+    expect(regions[0].delta[1]).toBeCloseTo(0.4, 10)
+    expect(regions[0].i).toBe(0)
+  })
+})
+
+describe("forHorizontal", () => {
+  it("splits the drawing into n full-height columns", () => {
+    const s = new SolandraSvg(200, 100, 1) // aspectRatio 2, height 0.5
+    const regions = collectRegions((cb) => s.forHorizontal({ n: 2 }, cb))
+
+    expect(regions.map((r) => r.point)).toEqual([
+      [0, 0],
+      [0.5, 0],
+    ])
+    for (const r of regions) {
+      expect(r.delta).toEqual([0.5, 0.5])
+    }
+    expect(regions.map((r) => r.center)).toEqual([
+      [0.25, 0.25],
+      [0.75, 0.25],
+    ])
+  })
+
+  it("respects the margin on both axes", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const regions = collectRegions((cb) =>
+      s.forHorizontal({ n: 2, margin: 0.1 }, cb),
+    )
+
+    expect(regions[0].point).toEqual([0.1, 0.1])
+    expect(regions[0].delta[0]).toBeCloseTo(0.4, 10)
+    expect(regions[0].delta[1]).toBeCloseTo(0.8, 10)
+    expect(regions[1].point[0]).toBeCloseTo(0.5, 10)
+  })
+})
+
+describe("forVertical", () => {
+  it("splits the drawing into n full-width rows", () => {
+    const s = new SolandraSvg(200, 100, 1)
+    const regions = collectRegions((cb) => s.forVertical({ n: 2 }, cb))
+
+    expect(regions.map((r) => r.point)).toEqual([
+      [0, 0],
+      [0, 0.25],
+    ])
+    for (const r of regions) {
+      expect(r.delta).toEqual([1, 0.25])
+    }
+  })
+
+  it("respects the margin on both axes", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const regions = collectRegions((cb) =>
+      s.forVertical({ n: 2, margin: 0.1 }, cb),
+    )
+
+    expect(regions[0].point).toEqual([0.1, 0.1])
+    expect(regions[0].delta[0]).toBeCloseTo(0.8, 10)
+    expect(regions[0].delta[1]).toBeCloseTo(0.4, 10)
+    expect(regions[1].point[1]).toBeCloseTo(0.5, 10)
+  })
+})
+
+describe("forGrid", () => {
+  it("visits every integer point, inclusive of the bounds, column first", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const points: Point2D[] = []
+    const indices: number[] = []
+    s.forGrid({ minX: 0, maxX: 1, minY: 0, maxY: 1 }, (p, i) => {
+      points.push(p)
+      indices.push(i)
+    })
+
+    expect(points).toEqual([
+      [0, 0],
+      [0, 1],
+      [1, 0],
+      [1, 1],
+    ])
+    expect(indices).toEqual([0, 1, 2, 3])
+  })
+
+  it("walks across rows when order is rowFirst", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const points: Point2D[] = []
+    s.forGrid({ minX: 0, maxX: 1, minY: 0, maxY: 1, order: "rowFirst" }, (p) =>
+      points.push(p),
+    )
+
+    expect(points).toEqual([
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ])
+  })
+
+  it("supports negative bounds", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const points: Point2D[] = []
+    s.forGrid({ minX: -1, maxX: 0, minY: -2, maxY: -1 }, (p) => points.push(p))
+
+    expect(points).toEqual([
+      [-1, -2],
+      [-1, -1],
+      [0, -2],
+      [0, -1],
+    ])
+  })
+
+  it("visits nothing when the bounds are inverted", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const points: Point2D[] = []
+    s.forGrid({ minX: 1, maxX: 0, minY: 0, maxY: 0 }, (p) => points.push(p))
+
+    expect(points).toEqual([])
+  })
+})
+
+describe("build", () => {
+  it("collects a value per iteration", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const indices = s.build(s.forTiling, { n: 2 }, (_p, _d, _c, i) => i)
+
+    expect(indices).toEqual([0, 1, 2, 3])
+  })
+
+  it("works with forGrid too", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const sums = s.build(
+      s.forGrid,
+      { minX: 0, maxX: 1, minY: 0, maxY: 1 },
+      ([x, y]: Point2D) => x + y,
+    )
+
+    expect(sums).toEqual([0, 1, 1, 2])
+  })
+})
+
+describe("withRandomOrder", () => {
+  it("visits every iteration exactly once, in a different order", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const seen: number[] = []
+    s.withRandomOrder(s.forTiling, { n: 4 }, (_p, _d, _c, i: number) =>
+      seen.push(i),
+    )
+
+    expect([...seen].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 16 }, (_, i) => i),
+    )
+    expect(seen).not.toEqual(Array.from({ length: 16 }, (_, i) => i))
+  })
+
+  it("is deterministic for a given seed", () => {
+    const order = (seed: number) => {
+      const s = new SolandraSvg(100, 100, seed)
+      const seen: number[] = []
+      s.withRandomOrder(s.forTiling, { n: 3 }, (_p, _d, _c, i: number) =>
+        seen.push(i),
+      )
+      return seen
+    }
+
+    expect(order(5)).toEqual(order(5))
+    expect(order(5)).not.toEqual(order(6))
+  })
+})
+
+describe("range", () => {
+  it("includes both endpoints by default", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const values: number[] = []
+    s.range({ n: 4 }, (n) => values.push(n))
+
+    expect(values).toEqual([0, 0.25, 0.5, 0.75, 1])
+  })
+
+  it("excludes the endpoint when inclusive is false", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const values: number[] = []
+    s.range({ n: 4, inclusive: false }, (n) => values.push(n))
+
+    expect(values).toEqual([0, 0.25, 0.5, 0.75])
+  })
+
+  it("honours from and to", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const values: number[] = []
+    s.range({ from: 10, to: 20, n: 2 }, (n) => values.push(n))
+
+    expect(values).toEqual([10, 15, 20])
+  })
+})
+
+describe("times and downFrom", () => {
+  it("times counts up from zero", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const values: number[] = []
+    s.times(3, (n) => values.push(n))
+    expect(values).toEqual([0, 1, 2])
+  })
+
+  it("downFrom counts down to one", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const values: number[] = []
+    s.downFrom(3, (n) => values.push(n))
+    expect(values).toEqual([3, 2, 1])
+  })
+
+  it("both do nothing for n = 0", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    let calls = 0
+    s.times(0, () => calls++)
+    s.downFrom(0, () => calls++)
+    expect(calls).toBe(0)
+  })
+})
+
+describe("doProportion", () => {
+  it("never runs for p = 0 and always runs for p = 1", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    let never = 0
+    let always = 0
+    for (let i = 0; i < 50; i++) {
+      s.doProportion(0, () => never++)
+      s.doProportion(1, () => always++)
+    }
+    expect(never).toBe(0)
+    expect(always).toBe(50)
+  })
+
+  it("runs roughly p of the time", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    let count = 0
+    for (let i = 0; i < 4000; i++) {
+      s.doProportion(0.25, () => count++)
+    }
+    expect(count).toBeGreaterThan(800)
+    expect(count).toBeLessThan(1200)
+  })
+})
+
+describe("inDrawing", () => {
+  it("is true strictly inside the drawing and false on the boundary", () => {
+    const s = new SolandraSvg(200, 100, 1) // 1 x 0.5
+
+    expect(s.inDrawing(s.meta.center)).toBe(true)
+    expect(s.inDrawing([0.5, 0.25])).toBe(true)
+    expect(s.inDrawing([0, 0.25])).toBe(false)
+    expect(s.inDrawing([1, 0.25])).toBe(false)
+    expect(s.inDrawing([0.5, 0])).toBe(false)
+    expect(s.inDrawing([0.5, 0.5])).toBe(false)
+    expect(s.inDrawing([-0.1, 0.25])).toBe(false)
+    expect(s.inDrawing([0.5, 0.6])).toBe(false)
+  })
+})

--- a/src/lib/__tests__/svgOutput.test.ts
+++ b/src/lib/__tests__/svgOutput.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest"
+import { SolandraSvg } from "../svg"
+import { Attributes } from "../attributes"
+
+const square = (s: SolandraSvg) =>
+  s.path(new Attributes().fill(0, 100, 50)).rect([0.5, 0.5], 0.5, 0.5)
+
+describe("imageSrc", () => {
+  it("URI-encodes the SVG by default", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    square(s)
+
+    const src = s.imageSrc()
+    expect(src.startsWith("data:image/svg+xml;utf8,")).toBe(true)
+    expect(
+      decodeURIComponent(src.slice("data:image/svg+xml;utf8,".length)),
+    ).toBe(s.image)
+  })
+
+  it("only escapes hashes when encode is false", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    square(s)
+
+    const src = s.imageSrc(false)
+    // The fill is a hex colour, so the '#' must be escaped to stay a valid URI.
+    expect(src).not.toContain("#")
+    expect(src).toContain("%23FF0000")
+    expect(src).toContain("<svg")
+  })
+})
+
+describe("UNSTABLE_imageInkscapeReady", () => {
+  it("renders the same body as image, with mm dimensions", () => {
+    const s = new SolandraSvg(210, 297, 1)
+    square(s)
+
+    expect(s.UNSTABLE_imageInkscapeReady).toContain(`width="210mm"`)
+    expect(s.UNSTABLE_imageInkscapeReady).toContain(`height="297mm"`)
+    expect(s.image).toContain(`width="210"`)
+
+    // Only the width/height attributes differ between the two renderings.
+    expect(s.UNSTABLE_imageInkscapeReady.replace(/(\d)mm"/g, '$1"')).toBe(
+      s.image,
+    )
+  })
+
+  it("has a data URI variant matching the encode flag", () => {
+    const s = new SolandraSvg(210, 297, 1)
+    square(s)
+
+    const encoded = s.UNSTABLE_imageSrcInkscapeReady()
+    expect(
+      decodeURIComponent(encoded.slice("data:image/svg+xml;utf8,".length)),
+    ).toBe(s.UNSTABLE_imageInkscapeReady)
+
+    const raw = s.UNSTABLE_imageSrcInkscapeReady(false)
+    expect(raw).not.toContain("#")
+    expect(raw).toContain("mm")
+  })
+})
+
+describe("groupWithId", () => {
+  it("wraps its contents in a g element with the given id", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    s.groupWithId("layer-1", () => {
+      s.path().moveTo([0, 0]).lineTo([1, 1])
+    })
+
+    expect(s.image).toMatchInlineSnapshot(`
+      "<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1" width="100" height="100">
+        <g id="layer-1">
+          <path d="M 0 0 L 1 1" />
+        </g>
+      </svg>"
+    `)
+  })
+
+  it("nests paths created inside it, not at the top level", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    s.groupWithId("a", () => {
+      s.path().moveTo([0, 0]).lineTo([1, 1])
+    })
+    s.path().moveTo([0, 1]).lineTo([1, 0])
+
+    expect(s.elements).toHaveLength(2)
+  })
+})
+
+describe("clonePath", () => {
+  it("adds an independent copy to the drawing", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const original = s.path().moveTo([0, 0]).lineTo([0.5, 0.5])
+    const copy = s.clonePath(original)
+
+    expect(s.elements).toHaveLength(2)
+    expect(copy).not.toBe(original)
+    expect(copy.string(0)).toBe(original.string(0))
+
+    copy.lineTo([1, 1])
+    expect(original.segments).toHaveLength(2)
+    expect(copy.segments).toHaveLength(3)
+  })
+
+  it("can replace the attributes on the copy", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const original = s
+      .path(new Attributes().id("original"))
+      .moveTo([0, 0])
+      .lineTo([1, 1])
+    const copy = s.clonePath(original, new Attributes().id("copy"))
+
+    expect(copy.string(0)).toContain(`id="copy"`)
+    expect(original.string(0)).toContain(`id="original"`)
+  })
+
+  it("clones into the current group", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const original = s.path().moveTo([0, 0]).lineTo([1, 1])
+    s.groupWithId("g", () => {
+      s.clonePath(original)
+    })
+
+    expect(s.elements).toHaveLength(2)
+    expect(s.image).toContain('<g id="g">')
+  })
+})
+
+describe("path presets", () => {
+  it("filledPath defaults to opaque black fill", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    s.filledPath().moveTo([0, 0]).lineTo([1, 1])
+
+    expect(s.image).toContain(`style="fill:#000000; fill-opacity:1;"`)
+  })
+
+  it("cutPath and creasePath differ only in stroke lightness", () => {
+    const cut = new SolandraSvg(100, 100, 1)
+    cut.cutPath().moveTo([0, 0]).lineTo([1, 1])
+
+    const crease = new SolandraSvg(100, 100, 1)
+    crease.creasePath().moveTo([0, 0]).lineTo([1, 1])
+
+    expect(cut.image).toContain("stroke:#999999")
+    expect(crease.image).toContain("stroke:#E6E6E6")
+    expect(cut.image.replace("#999999", "#E6E6E6")).toBe(crease.image)
+  })
+
+  it("both presets round their caps and joins and accept overrides", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    s.cutPath((a) => a.strokeWidth(0.01))
+      .moveTo([0, 0])
+      .lineTo([1, 1])
+
+    const out = s.image
+    expect(out).toContain("stroke-linecap:round")
+    expect(out).toContain("stroke-linejoin:round")
+    expect(out).toContain("stroke-width:0.01")
+    expect(out).not.toContain("stroke-width:0.005")
+  })
+
+  it("presets are added to the current group", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    s.groupWithId("cuts", () => {
+      s.cutPath().moveTo([0, 0]).lineTo([1, 1])
+      s.creasePath().moveTo([0, 1]).lineTo([1, 0])
+    })
+
+    expect(s.elements).toHaveLength(1)
+    expect(s.image.match(/<path/g)).toHaveLength(2)
+  })
+})

--- a/src/lib/__tests__/svgRandom.test.ts
+++ b/src/lib/__tests__/svgRandom.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest"
+import { SolandraSvg } from "../svg"
+import { Point2D } from "../util/types"
+
+describe("random", () => {
+  it("stays in [0, 1) and is reproducible for a seed", () => {
+    const a = new SolandraSvg(100, 100, 11)
+    const b = new SolandraSvg(100, 100, 11)
+
+    for (let i = 0; i < 100; i++) {
+      const n = a.random()
+      expect(n).toBeGreaterThanOrEqual(0)
+      expect(n).toBeLessThan(1)
+      expect(n).toBe(b.random())
+    }
+  })
+})
+
+describe("randomAngle", () => {
+  it("stays in [0, 2pi)", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    for (let i = 0; i < 200; i++) {
+      const a = s.randomAngle()
+      expect(a).toBeGreaterThanOrEqual(0)
+      expect(a).toBeLessThan(Math.PI * 2)
+    }
+  })
+})
+
+describe("randomPoint", () => {
+  it("lands inside the drawing bounds", () => {
+    const s = new SolandraSvg(200, 100, 1) // 1 x 0.5
+
+    for (let i = 0; i < 200; i++) {
+      const [x, y] = s.randomPoint()
+      expect(x).toBeGreaterThanOrEqual(0)
+      expect(x).toBeLessThan(1)
+      expect(y).toBeGreaterThanOrEqual(0)
+      expect(y).toBeLessThan(0.5)
+    }
+  })
+})
+
+describe("randomPolarity", () => {
+  it("only returns 1 or -1, and returns both", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const seen = new Set<number>()
+    for (let i = 0; i < 100; i++) {
+      const p = s.randomPolarity()
+      expect(Math.abs(p)).toBe(1)
+      seen.add(p)
+    }
+    expect(seen).toEqual(new Set([1, -1]))
+  })
+})
+
+describe("uniformGridPoint", () => {
+  it("returns integer points inside the inclusive bounds", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    for (let i = 0; i < 200; i++) {
+      const [x, y] = s.uniformGridPoint({
+        minX: -2,
+        maxX: 2,
+        minY: 0,
+        maxY: 3,
+      })
+      expect(Number.isInteger(x)).toBe(true)
+      expect(Number.isInteger(y)).toBe(true)
+      expect(x).toBeGreaterThanOrEqual(-2)
+      expect(x).toBeLessThanOrEqual(2)
+      expect(y).toBeGreaterThanOrEqual(0)
+      expect(y).toBeLessThanOrEqual(3)
+    }
+  })
+
+  it("can reach every point of a small grid", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const seen = new Set<string>()
+    for (let i = 0; i < 500; i++) {
+      seen.add(
+        s.uniformGridPoint({ minX: 0, maxX: 1, minY: 0, maxY: 1 }).join(),
+      )
+    }
+    expect(seen.size).toBe(4)
+  })
+})
+
+describe("sample and samples", () => {
+  it("sample always returns a member of the source array", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const source = ["a", "b", "c"]
+    for (let i = 0; i < 100; i++) {
+      expect(source).toContain(s.sample(source))
+    }
+  })
+
+  it("sample reaches every element eventually", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const source = ["a", "b", "c"]
+    const seen = new Set(Array.from({ length: 200 }, () => s.sample(source)))
+    expect(seen).toEqual(new Set(source))
+  })
+
+  it("samples returns n elements, with replacement", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const result = s.samples(10, [1, 2])
+
+    expect(result).toHaveLength(10)
+    for (const n of result) {
+      expect([1, 2]).toContain(n)
+    }
+  })
+
+  it("samples returns an empty array for n = 0", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    expect(s.samples(0, [1, 2, 3])).toEqual([])
+  })
+})
+
+describe("shuffle", () => {
+  it("permutes in place, preserving every element", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const items = Array.from({ length: 20 }, (_, i) => i)
+    const result = s.shuffle(items)
+
+    expect(result).toBe(items)
+    expect([...result].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 20 }, (_, i) => i),
+    )
+    expect(result).not.toEqual(Array.from({ length: 20 }, (_, i) => i))
+  })
+
+  it("is deterministic for a given seed", () => {
+    const shuffled = (seed: number) =>
+      new SolandraSvg(100, 100, seed).shuffle([1, 2, 3, 4, 5, 6, 7, 8])
+
+    expect(shuffled(3)).toEqual(shuffled(3))
+    expect(shuffled(3)).not.toEqual(shuffled(4))
+  })
+
+  it("handles empty and single-element arrays", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    expect(s.shuffle([])).toEqual([])
+    expect(s.shuffle(["only"])).toEqual(["only"])
+  })
+})
+
+describe("perturb", () => {
+  it("offsets a point by at most magnitude/2 on each axis", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const at: Point2D = [0.5, 0.5]
+
+    for (let i = 0; i < 200; i++) {
+      const [x, y] = s.perturb({ at, magnitude: 0.4 })
+      expect(Math.abs(x - 0.5)).toBeLessThanOrEqual(0.2)
+      expect(Math.abs(y - 0.5)).toBeLessThanOrEqual(0.2)
+    }
+  })
+
+  it("defaults to a magnitude of 0.1", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    for (let i = 0; i < 200; i++) {
+      const [x, y] = s.perturb({ at: [0, 0] })
+      expect(Math.abs(x)).toBeLessThanOrEqual(0.05)
+      expect(Math.abs(y)).toBeLessThanOrEqual(0.05)
+    }
+  })
+
+  it("does not mutate the input point", () => {
+    const s = new SolandraSvg(100, 100, 1)
+    const at: Point2D = [0.25, 0.75]
+    s.perturb({ at })
+    expect(at).toEqual([0.25, 0.75])
+  })
+})
+
+describe("seeding", () => {
+  it("gives identical drawings for identical seeds", () => {
+    const draw = (seed: number) => {
+      const s = new SolandraSvg(100, 100, seed)
+      s.forTiling({ n: 3 }, (_p, _d, c) => {
+        s.filledPath((a) => a.fill(s.random() * 360, 80, 50)).ellipse(
+          s.perturb({ at: c }),
+          0.1,
+          0.1,
+        )
+      })
+      return s.image
+    }
+
+    expect(draw(42)).toBe(draw(42))
+    expect(draw(42)).not.toBe(draw(43))
+  })
+})

--- a/src/lib/__tests__/util.test.ts
+++ b/src/lib/__tests__/util.test.ts
@@ -23,6 +23,34 @@ describe("Colour calc", () => {
 
     expect(hslToRgb(0, 0, 1)).toBe("#FFFFFF")
   })
+
+  it("should always produce a six digit hex string", () => {
+    // Channels below 0x10 must be zero padded, not truncated.
+    expect(hslToRgb(0, 0, 1 / 255)).toBe("#010101")
+    expect(hslToRgb(0, 1, 0.02)).toBe("#0A0000")
+
+    for (let i = 0; i <= 100; i++) {
+      expect(hslToRgb(i / 100, 0.5, i / 100)).toMatch(/^#[0-9A-F]{6}$/)
+    }
+  })
+
+  it("should wrap hues outside the 0-1 range", () => {
+    // Hue is cyclic: 1 is the same as 0, and 1.5 the same as 0.5.
+    expect(hslToRgb(0, 1, 0.5)).toBe("#FF0000")
+    expect(hslToRgb(1, 1, 0.5)).toBe("#FF0000")
+    expect(hslToRgb(2, 1, 0.5)).toBe("#FF0000")
+    expect(hslToRgb(-1, 1, 0.5)).toBe("#FF0000")
+
+    expect(hslToRgb(0.5, 1, 0.5)).toBe("#00FFFF")
+    expect(hslToRgb(1.5, 1, 0.5)).toBe("#00FFFF")
+    expect(hslToRgb(-0.5, 1, 0.5)).toBe("#00FFFF")
+  })
+
+  it("should clamp out of range saturation and lightness", () => {
+    expect(hslToRgb(0, 0, 1.5)).toBe("#FFFFFF")
+    expect(hslToRgb(0, 0, -0.5)).toBe("#000000")
+    expect(hslToRgb(0.5, 2, 0.5)).toMatch(/^#[0-9A-F]{6}$/)
+  })
 })
 
 describe("Scalar utilities", () => {

--- a/src/lib/attributes.ts
+++ b/src/lib/attributes.ts
@@ -49,14 +49,36 @@ export class Attributes {
     hue: number,
     saturation: number,
     lightness: number,
-    opacity?: number
+    opacity?: number,
   ): Attributes {
-    this.styleAttributes["fill"] = hslToRgb(
+    return this.setHsl("fill", hue, saturation, lightness, opacity)
+  }
+
+  /**
+   * Sets a paint property to an HSL colour (as hex RGB), with optional opacity.
+   *
+   * @param property - Either `"fill"` or `"stroke"`
+   * @param hue - Hue from `0` to `360`
+   * @param saturation - Saturation from `0` to `100`
+   * @param lightness - Lightness from `0` to `100`
+   * @param opacity - Optional opacity from `0` to `1`
+   * @returns `this` for chaining
+   */
+  private setHsl(
+    property: "fill" | "stroke",
+    hue: number,
+    saturation: number,
+    lightness: number,
+    opacity?: number,
+  ): Attributes {
+    this.styleAttributes[property] = hslToRgb(
       hue / 360,
       saturation / 100,
-      lightness / 100
+      lightness / 100,
     )
-    if (opacity !== undefined) this.styleAttributes["fill-opacity"] = opacity
+    if (opacity !== undefined) {
+      this.styleAttributes[`${property}-opacity`] = opacity
+    }
     return this
   }
 
@@ -90,17 +112,17 @@ export class Attributes {
    * @param lightness - Perceptual lightness (typically `0` to `1`)
    * @param chroma - Colour intensity (typically `0` to `0.4`)
    * @param hue - Hue angle in degrees (`0` to `360`)
-   * @param alpha - Opacity from `0` to `1`
+   * @param alpha - Optional opacity from `0` to `1`, embedded in the `oklch()` value
    * @returns `this` for chaining
    */
   fillOklch(
     lightness: number,
     chroma: number,
     hue: number,
-    alpha: number
+    alpha?: number,
   ): Attributes {
     this.styleAttributes["fill"] = `oklch(${lightness} ${chroma} ${hue}${
-      typeof alpha === "number" ? ` / ${alpha * 100}%` : ""
+      alpha !== undefined ? ` / ${alpha * 100}%` : ""
     })`
     return this
   }
@@ -119,15 +141,9 @@ export class Attributes {
     hue: number,
     saturation: number,
     lightness: number,
-    alpha?: number
+    alpha?: number,
   ): Attributes {
-    this.styleAttributes["stroke"] = hslToRgb(
-      hue / 360,
-      saturation / 100,
-      lightness / 100
-    )
-    if (alpha !== undefined) this.styleAttributes["stroke-opacity"] = alpha
-    return this
+    return this.setHsl("stroke", hue, saturation, lightness, alpha)
   }
 
   /**
@@ -136,19 +152,20 @@ export class Attributes {
    * @param lightness - Perceptual lightness (typically `0` to `1`)
    * @param chroma - Colour intensity (typically `0` to `0.4`)
    * @param hue - Hue angle in degrees (`0` to `360`)
-   * @param alpha - Stroke opacity from `0` to `1`
+   * @param alpha - Optional stroke opacity from `0` to `1`, set as `stroke-opacity`
    * @returns `this` for chaining
    */
   strokeOklch(
     lightness: number,
     chroma: number,
     hue: number,
-    alpha: number
+    alpha?: number,
   ): Attributes {
     this.styleAttributes["stroke"] = `oklch(${lightness} ${chroma} ${hue})`
 
-    if (typeof alpha === "number")
+    if (alpha !== undefined) {
       this.styleAttributes["stroke-opacity"] = alpha
+    }
 
     return this
   }

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -28,8 +28,16 @@ export type PathSegment =
   | { kind: "arc"; to: Point2D; config: Required<ArcConfig> }
   | { kind: "close" }
 
-// To force types later, a bit nasty but to cover most potential errors with runtime checks
-type Toable = { to: Point2D }
+/**
+ * Returns the point a segment finishes at, or `undefined` for segments that
+ * have no destination of their own (i.e. `close`).
+ *
+ * @param segment - The segment to inspect
+ * @internal
+ */
+function endPointOf(segment: PathSegment | undefined): Point2D | undefined {
+  return segment && segment.kind !== "close" ? segment.to : undefined
+}
 
 function cloneSegment(segment: PathSegment): PathSegment {
   switch (segment.kind) {
@@ -71,12 +79,17 @@ function segmentToString(segment: PathSegment, previous?: Point2D): string {
     case "line":
       return `L ${segment.to.join(" ")}`
     case "cubicCurve":
+      if (!previous) {
+        throw new Error(
+          "A curve must follow a segment with a destination point",
+        )
+      }
       return convertToSVGCubicSpec({
-        from: previous!,
+        from: previous,
         to: segment.to,
         ...segment.config,
       })
-    case "arc":
+    case "arc": {
       const {
         config: { rX, rY, largeArc, sweep, xAxisRotation },
         to,
@@ -84,6 +97,7 @@ function segmentToString(segment: PathSegment, previous?: Point2D): string {
       return `A ${rX} ${rY} ${xAxisRotation} ${largeArc ? 1 : 0} ${
         sweep ? 1 : 0
       } ${to[0]} ${to[1]}`
+    }
   }
 }
 
@@ -176,14 +190,13 @@ export class Path {
    * @returns `this` for chaining
    */
   arcTo(point: Point2D, config: ArcConfig = {}): Path {
-    const prev = this.segments[this.segments.length - 1]
-    if (!prev || prev.kind === "close") {
+    const previous = endPointOf(this.segments[this.segments.length - 1])
+    if (!previous) {
       throw new Error(
         "arcTo requires a previous segment with a destination point",
       )
     }
 
-    const previous: Point2D = prev.to
     const {
       rX = Math.abs(point[0] - previous[0]),
       rY = Math.abs(point[1] - previous[1]),
@@ -224,12 +237,11 @@ export class Path {
   ): Path {
     const start =
       align === "topLeft" ? at : v.subtract(at, [width / 2, height / 2])
-    this.segments.push({ kind: "move", to: start })
-    this.segments.push({ kind: "line", to: v.add(start, [width, 0]) })
-    this.segments.push({ kind: "line", to: v.add(start, [width, height]) })
-    this.segments.push({ kind: "line", to: v.add(start, [0, height]) })
-    this.segments.push({ kind: "line", to: start })
-    return this
+    return this.moveTo(start)
+      .lineTo(v.add(start, [width, 0]))
+      .lineTo(v.add(start, [width, height]))
+      .lineTo(v.add(start, [0, height]))
+      .lineTo(start)
   }
 
   /**
@@ -251,19 +263,10 @@ export class Path {
   ): Path {
     const c = align === "topLeft" ? v.add(at, [radius, radius]) : at
 
-    let start: Point2D = [
-      c[0] + radius * Math.cos(rotate),
-      c[1] + radius * Math.sin(rotate),
-    ]
-
-    this.segments.push({ kind: "move", to: start })
+    this.moveTo(v.polarToCartesian(c, radius, rotate))
 
     for (let i = 1; i <= n; i++) {
-      const angle = (i * Math.PI * 2) / n + rotate
-      this.segments.push({
-        kind: "line",
-        to: [c[0] + radius * Math.cos(angle), c[1] + radius * Math.sin(angle)],
-      })
+      this.lineTo(v.polarToCartesian(c, radius, (i * Math.PI * 2) / n + rotate))
     }
 
     return this
@@ -292,7 +295,7 @@ export class Path {
 
     // draw from top, seems most natural, like a clock?
     // four quarter arcs counterclockwise: top, left, bottom, right, back to top
-    this.segments.push({ kind: "move", to: [cX, cY - rY] })
+    this.moveTo([cX, cY - rY])
     for (let i = 0; i < 4; i++) {
       const angle = ((i + 2) * Math.PI) / 2
       this.arcTo([cX + rX * Math.cos(angle), cY - rY * Math.sin(angle)], {
@@ -323,19 +326,13 @@ export class Path {
     let a = angle
     let r = l
 
-    this.segments.push({
-      kind: "move",
-      to: v.add(at, [r * Math.cos(a), r * Math.sin(a)]),
-    })
+    this.moveTo(v.polarToCartesian(at, r, a))
 
     for (let i = 0; i < n; i++) {
       const dA = 2 * Math.asin(l / (r * 2))
       r += rate * dA
       a += dA
-      this.segments.push({
-        kind: "line",
-        to: v.add(at, [r * Math.cos(a), r * Math.sin(a)]),
-      })
+      this.lineTo(v.polarToCartesian(at, r, a))
     }
 
     return this
@@ -367,14 +364,14 @@ export class Path {
       newSegments.push(this.segments[0])
 
       for (let i = 1; i < this.segments.length - 1; i++) {
-        const a = this.segments[i - 1]
+        const a = endPointOf(this.segments[i - 1])
         const b = this.segments[i]
         const c = this.segments[i + 1]
 
-        if (b.kind === "line" && c.kind === "line" && (a as Toable)["to"]) {
+        if (b.kind === "line" && c.kind === "line" && a) {
           newSegments.push({
             kind: "line",
-            to: v.pointAlong((a as Toable).to, b.to, 0.75),
+            to: v.pointAlong(a, b.to, 0.75),
           })
           newSegments.push({
             kind: "line",
@@ -429,12 +426,7 @@ export class Path {
       throw new Error("Must start path with move to initial position")
 
     const d = this.segments
-      .map((s, i) =>
-        segmentToString(
-          s,
-          i > 0 ? (this.segments[i - 1] as Toable).to : undefined,
-        ),
-      )
+      .map((s, i) => segmentToString(s, endPointOf(this.segments[i - 1])))
       .join(" ")
     return indent(`<path${this.attributes.string} d="${d}" />`, depth)
   }

--- a/src/lib/svg.ts
+++ b/src/lib/svg.ts
@@ -30,13 +30,7 @@ export class Group {
   strings(depth: number): string[] {
     return [
       indent(`<g${this.attributes.string}>`, depth),
-      ...this.children.flatMap((el) => {
-        if (el instanceof Group) {
-          return el.strings(depth + 1)
-        } else {
-          return el.string(depth + 1)
-        }
-      }),
+      ...this.children.flatMap((el) => renderElement(el, depth + 1)),
       indent(`</g>`, depth),
     ]
   }
@@ -48,6 +42,79 @@ export class Group {
    */
   push(element: Group | Path) {
     this.children.push(element)
+  }
+}
+
+/**
+ * Serialises a top-level or nested SVG element to indented markup lines.
+ *
+ * @param element - The group or path to serialise
+ * @param depth - The indentation depth for pretty-printing
+ * @internal
+ */
+function renderElement(element: Group | Path, depth: number): string[] {
+  return element instanceof Group
+    ? element.strings(depth)
+    : [element.string(depth)]
+}
+
+/**
+ * Wraps SVG markup in a `data:` URI suitable for use as an `<img>` `src`.
+ *
+ * @param svg - The SVG markup
+ * @param encode - If `true`, URI-encodes the SVG; otherwise only escapes `#` characters
+ * @internal
+ */
+function toDataUri(svg: string, encode: boolean): string {
+  return `data:image/svg+xml;utf8,${
+    encode ? encodeURIComponent(svg) : svg.replace(/#/g, "%23")
+  }`
+}
+
+/**
+ * The callback signature shared by the region-based iteration utilities
+ * ({@link SolandraSvg.forTiling}, {@link SolandraSvg.forHorizontal},
+ * {@link SolandraSvg.forVertical}, {@link SolandraSvg.forMargin}).
+ *
+ * @param point - The top-left corner of the region
+ * @param delta - The `[width, height]` of the region
+ * @param center - The center of the region
+ * @param i - The zero-based iteration index
+ */
+export type RegionCallback = (
+  point: Point2D,
+  delta: Vector2D,
+  center: Point2D,
+  i: number,
+) => void
+
+/**
+ * Visits every `(i, j)` cell of an `nX` by `nY` grid in the requested order.
+ *
+ * @param nX - The number of columns
+ * @param nY - The number of rows
+ * @param order - `"columnFirst"` walks down each column, `"rowFirst"` across each row
+ * @param visit - Called with the column and row index of each cell
+ * @internal
+ */
+function forEachCell(
+  nX: number,
+  nY: number,
+  order: "columnFirst" | "rowFirst",
+  visit: (i: number, j: number) => void,
+) {
+  if (order === "columnFirst") {
+    for (let i = 0; i < nX; i++) {
+      for (let j = 0; j < nY; j++) {
+        visit(i, j)
+      }
+    }
+  } else {
+    for (let j = 0; j < nY; j++) {
+      for (let i = 0; i < nX; i++) {
+        visit(i, j)
+      }
+    }
   }
 }
 
@@ -99,24 +166,28 @@ export class SolandraSvg {
   }
 
   /**
+   * Renders the drawing as SVG markup, with the given unit suffix on the
+   * `width`/`height` attributes.
+   *
+   * @param unit - The CSS unit appended to the pixel dimensions (e.g. `""` or `"mm"`)
+   * @internal
+   */
+  private render(unit: string): string {
+    const body = this.elements.flatMap((el) => renderElement(el, 1)).join("\n")
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 ${
+      1 / this.aspectRatio
+    }" width="${this.width}${unit}" height="${this.height}${unit}">
+${body}
+</svg>`
+  }
+
+  /**
    * Generates the complete SVG markup string for the drawing.
    *
    * The viewBox is normalised to `"0 0 1 {1/aspectRatio}"`.
    */
   get image(): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 ${
-      1 / this.aspectRatio
-    }" width="${this.width}" height="${this.height}">
-${this.elements
-  .flatMap((el) => {
-    if (el instanceof Group) {
-      return el.strings(1)
-    } else {
-      return el.string(1)
-    }
-  })
-  .join("\n")}
-</svg>`
+    return this.render("")
   }
 
   /**
@@ -126,9 +197,7 @@ ${this.elements
    * @returns A `data:image/svg+xml` URI string
    */
   imageSrc(encode: boolean = true): string {
-    return `data:image/svg+xml;utf8,${
-      encode ? encodeURIComponent(this.image) : this.image.replace(/#/g, "%23")
-    }`
+    return toDataUri(this.image, encode)
   }
 
   /**
@@ -137,19 +206,7 @@ ${this.elements
    * @remarks This API is unstable and may change.
    */
   get UNSTABLE_imageInkscapeReady(): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 ${
-      1 / this.aspectRatio
-    }" width="${this.width}mm" height="${this.height}mm">
-${this.elements
-  .flatMap((el) => {
-    if (el instanceof Group) {
-      return el.strings(1)
-    } else {
-      return el.string(1)
-    }
-  })
-  .join("\n")}
-</svg>`
+    return this.render("mm")
   }
 
   /**
@@ -160,11 +217,7 @@ ${this.elements
    * @remarks This API is unstable and may change.
    */
   UNSTABLE_imageSrcInkscapeReady(encode: boolean = true): string {
-    return `data:image/svg+xml;utf8,${
-      encode
-        ? encodeURIComponent(this.UNSTABLE_imageInkscapeReady)
-        : this.UNSTABLE_imageInkscapeReady.replace(/#/g, "%23")
-    }`
+    return toDataUri(this.UNSTABLE_imageInkscapeReady, encode)
   }
 
   /**
@@ -210,15 +263,25 @@ ${this.elements
   }
 
   /**
+   * Adds an already-constructed path to the current drawing context.
+   *
+   * @param path - The path to add
+   * @returns The same path, for convenience
+   * @internal
+   */
+  private addPath(path: Path): Path {
+    this.currentElements.push(path)
+    return path
+  }
+
+  /**
    * Creates a new {@link Path} and adds it to the current drawing context.
    *
    * @param attributes - Optional {@link Attributes} for the path (defaults to empty)
    * @returns The new path, ready for drawing commands
    */
   path(attributes: Attributes = new Attributes()): Path {
-    const path = new Path(attributes)
-    this.currentElements.push(path)
-    return path
+    return this.addPath(new Path(attributes))
   }
 
   /**
@@ -236,9 +299,7 @@ ${this.elements
       .strokeOpacity(1)
       .lineCap("round")
     configureAttributes?.(attr)
-    const path = new Path(attr)
-    this.currentElements.push(path)
-    return path
+    return this.addPath(new Path(attr))
   }
 
   /**
@@ -252,9 +313,7 @@ ${this.elements
   filledPath(configureAttributes?: (attributes: Attributes) => void): Path {
     const attr = Attributes.filled.fill(0, 0, 0).fillOpacity(1)
     configureAttributes?.(attr)
-    const path = new Path(attr)
-    this.currentElements.push(path)
-    return path
+    return this.addPath(new Path(attr))
   }
 
   /**
@@ -265,9 +324,27 @@ ${this.elements
    * @returns The cloned path (now part of the drawing)
    */
   clonePath(path: Path, attributes?: Attributes): Path {
-    const newPath = path.clone(attributes)
-    this.currentElements.push(newPath)
-    return newPath
+    return this.addPath(path.clone(attributes))
+  }
+
+  /**
+   * Creates a stroked path preset for cut-and-fold designs.
+   *
+   * @param lightness - The stroke lightness (`0`-`100`)
+   * @param configureAttributes - Optional callback to further customise the attributes
+   * @internal
+   */
+  private cutAndFoldPath(
+    lightness: number,
+    configureAttributes?: (attributes: Attributes) => void,
+  ): Path {
+    return this.strokedPath((a) => {
+      a.lineCap("round")
+        .lineJoin("round")
+        .stroke(0, 0, lightness)
+        .strokeWidth(0.005)
+      configureAttributes?.(a)
+    })
   }
 
   /**
@@ -279,10 +356,7 @@ ${this.elements
    * @returns The new cut path
    */
   cutPath(configureAttributes?: (attributes: Attributes) => void) {
-    return this.strokedPath((a) => {
-      a.lineCap("round").lineJoin("round").stroke(0, 0, 60).strokeWidth(0.005)
-      configureAttributes?.(a)
-    })
+    return this.cutAndFoldPath(60, configureAttributes)
   }
 
   /**
@@ -294,10 +368,7 @@ ${this.elements
    * @returns The new crease path
    */
   creasePath(configureAttributes?: (attributes: Attributes) => void) {
-    return this.strokedPath((a) => {
-      a.lineCap("round").lineJoin("round").stroke(0, 0, 90).strokeWidth(0.005)
-      configureAttributes?.(a)
-    })
+    return this.cutAndFoldPath(90, configureAttributes)
   }
 
   // ── Iteration utilities ────────────────────────────────────────────
@@ -310,15 +381,8 @@ ${this.elements
    * @param margin - The margin around the drawing area (in normalised coordinates)
    * @param callback - Called with the top-left point, the size delta, the center, and index `0`
    */
-  forMargin = (
-    margin: number,
-    callback: (
-      point: Point2D,
-      delta: Vector2D,
-      center: Point2D,
-      i: number,
-    ) => void,
-  ) => this.forTiling({ n: 1, margin }, callback)
+  forMargin = (margin: number, callback: RegionCallback) =>
+    this.forTiling({ n: 1, margin }, callback)
 
   /**
    * Tiles the drawing area into a grid of cells and iterates over each cell.
@@ -337,12 +401,7 @@ ${this.elements
       margin?: number
       order?: "columnFirst" | "rowFirst"
     },
-    callback: (
-      point: Point2D,
-      delta: Vector2D,
-      center: Point2D,
-      i: number,
-    ) => void,
+    callback: RegionCallback,
   ) => {
     let k = 0
     const {
@@ -361,31 +420,14 @@ ${this.elements
     const sX = margin
     const sY = (1 / this.aspectRatio - hY) / 2
 
-    if (order === "columnFirst") {
-      for (let i = 0; i < n; i++) {
-        for (let j = 0; j < nY; j++) {
-          callback(
-            [sX + i * deltaX, sY + j * deltaY],
-            [deltaX, deltaY],
-            [sX + i * deltaX + deltaX / 2, sY + j * deltaY + deltaY / 2],
-            k,
-          )
-          k++
-        }
-      }
-    } else {
-      for (let j = 0; j < nY; j++) {
-        for (let i = 0; i < n; i++) {
-          callback(
-            [sX + i * deltaX, sY + j * deltaY],
-            [deltaX, deltaY],
-            [sX + i * deltaX + deltaX / 2, sY + j * deltaY + deltaY / 2],
-            k,
-          )
-          k++
-        }
-      }
+    const emit = (i: number, j: number) => {
+      const x = sX + i * deltaX
+      const y = sY + j * deltaY
+      callback([x, y], [deltaX, deltaY], [x + deltaX / 2, y + deltaY / 2], k)
+      k++
     }
+
+    forEachCell(n, nY, order, emit)
   }
 
   /**
@@ -397,34 +439,9 @@ ${this.elements
    * @param callback - Called for each strip with `(topLeft, stripSize, stripCenter, index)`
    */
   forHorizontal = (
-    config: {
-      n: number
-      margin?: number
-    },
-    callback: (
-      point: Point2D,
-      delta: Vector2D,
-      center: Point2D,
-      i: number,
-    ) => void,
-  ) => {
-    const { n, margin = 0 } = config
-
-    const sX = margin
-    const eX = 1 - margin
-    const sY = margin
-    const dY = 1 / this.aspectRatio - 2 * margin
-    const dX = (eX - sX) / n
-
-    for (let i = 0; i < n; i++) {
-      callback(
-        [sX + i * dX, sY],
-        [dX, dY],
-        [sX + i * dX + dX / 2, sY + dY / 2],
-        i,
-      )
-    }
-  }
+    config: { n: number; margin?: number },
+    callback: RegionCallback,
+  ) => this.forStrips(config, "horizontal", callback)
 
   /**
    * Divides the drawing area into `n` vertical strips and iterates over each.
@@ -435,32 +452,33 @@ ${this.elements
    * @param callback - Called for each strip with `(topLeft, stripSize, stripCenter, index)`
    */
   forVertical = (
-    config: {
-      n: number
-      margin?: number
-    },
-    callback: (
-      point: Point2D,
-      delta: Vector2D,
-      center: Point2D,
-      i: number,
-    ) => void,
-  ) => {
-    const { n, margin = 0 } = config
+    config: { n: number; margin?: number },
+    callback: RegionCallback,
+  ) => this.forStrips(config, "vertical", callback)
 
-    const sX = margin
-    const eY = 1 / this.aspectRatio - margin
-    const sY = margin
-    const dX = 1 - 2 * margin
-    const dY = (eY - sY) / n
+  /**
+   * Divides the drawing area into `n` strips along one axis and iterates over each.
+   *
+   * @param config - Strip count and margin
+   * @param direction - `"horizontal"` splits along x, `"vertical"` along y
+   * @param callback - Called for each strip
+   * @internal
+   */
+  private forStrips(
+    { n, margin = 0 }: { n: number; margin?: number },
+    direction: "horizontal" | "vertical",
+    callback: RegionCallback,
+  ) {
+    const horizontal = direction === "horizontal"
+    const width = 1 - 2 * margin
+    const height = 1 / this.aspectRatio - 2 * margin
+    const dX = horizontal ? width / n : width
+    const dY = horizontal ? height : height / n
 
     for (let i = 0; i < n; i++) {
-      callback(
-        [sX, sY + i * dY],
-        [dX, dY],
-        [sX + dX / 2, sY + i * dY + dY / 2],
-        i,
-      )
+      const x = margin + (horizontal ? i * dX : 0)
+      const y = margin + (horizontal ? 0 : i * dY)
+      callback([x, y], [dX, dY], [x + dX / 2, y + dY / 2], i)
     }
   }
 
@@ -488,21 +506,10 @@ ${this.elements
     let k = 0
     const { minX, maxX, minY, maxY, order = "columnFirst" } = config
 
-    if (order === "columnFirst") {
-      for (let i = minX; i <= maxX; i++) {
-        for (let j = minY; j <= maxY; j++) {
-          callback([i, j], k)
-          k++
-        }
-      }
-    } else {
-      for (let j = minY; j <= maxY; j++) {
-        for (let i = minX; i <= maxX; i++) {
-          callback([i, j], k)
-          k++
-        }
-      }
-    }
+    forEachCell(maxX - minX + 1, maxY - minY + 1, order, (i, j) => {
+      callback([minX + i, minY + j], k)
+      k++
+    })
   }
 
   /**
@@ -545,7 +552,7 @@ ${this.elements
     })
     this.shuffle(args)
 
-    for (let a of args) {
+    for (const a of args) {
       cb(...a)
     }
   }

--- a/src/lib/util/colorCalcs.ts
+++ b/src/lib/util/colorCalcs.ts
@@ -1,17 +1,15 @@
-import { arrayOf } from "./collectionOps.js"
-
 /**
  * Converts a hue component to an RGB channel value.
  *
  * @param p - The first intermediate value from HSL conversion
  * @param q - The second intermediate value from HSL conversion
- * @param t - The hue offset (adjusted to `[0, 1]` range)
+ * @param t - The hue offset (wrapped into the `[0, 1)` range)
  * @returns The RGB channel value in the range `[0, 1]`
  * @internal
  */
 function hue2rgb(p: number, q: number, t: number): number {
-  if (t < 0) t += 1
-  if (t > 1) t -= 1
+  // hue is cyclic, so wrap any offset back into [0, 1)
+  t -= Math.floor(t)
   if (t < 1 / 6) return p + (q - p) * 6 * t
   if (t < 1 / 2) return q
   if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
@@ -19,43 +17,24 @@ function hue2rgb(p: number, q: number, t: number): number {
 }
 
 /**
- * Left-pads a string with zeros to reach the desired number of digits.
- *
- * @param n - The value to pad
- * @param digits - The minimum number of digits
- * @returns The zero-padded string
- * @internal
- */
-function padZeros(n: string | number, digits: number): string {
-  const nAsString = n.toString()
-  if (nAsString.length < digits) {
-    const padding = arrayOf(digits - nAsString.length, () => "0").join()
-    return padding + nAsString
-  } else {
-    return nAsString
-  }
-}
-
-/**
  * Converts a floating-point color channel value `[0, 1]` to a two-character uppercase hex string.
+ *
+ * Values outside `[0, 1]` are clamped so the result is always valid hex.
  *
  * @param n - The channel value in the range `[0, 1]`
  * @returns A two-character hex string (e.g. `"FF"`)
  * @internal
  */
 function toHexPart(n: number): string {
-  return padZeros(
-    Math.round(n * 255)
-      .toString(16)
-      .toUpperCase(),
-    2
-  )
+  const byte = Math.min(255, Math.max(0, Math.round(n * 255)))
+  return byte.toString(16).toUpperCase().padStart(2, "0")
 }
 
 /**
  * Converts an HSL color to an RGB hex string.
  *
- * All input values should be normalised to the range `[0, 1]`.
+ * All input values should be normalised to the range `[0, 1]`. Hues outside that
+ * range wrap around; saturation and lightness are clamped.
  *
  * @param h - Hue in `[0, 1]`
  * @param s - Saturation in `[0, 1]`
@@ -63,13 +42,15 @@ function toHexPart(n: number): string {
  * @returns An RGB hex string (e.g. `"#FF8800"`)
  */
 export function hslToRgb(h: number, s: number, l: number): string {
-  let r, g, b
+  let r: number
+  let g: number
+  let b: number
 
   if (s === 0) {
     r = g = b = l
   } else {
-    var q = l < 0.5 ? l * (1 + s) : l + s - l * s
-    var p = 2 * l - q
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+    const p = 2 * l - q
     r = hue2rgb(p, q, h + 1 / 3)
     g = hue2rgb(p, q, h)
     b = hue2rgb(p, q, h - 1 / 3)

--- a/src/lib/util/internalUtil.ts
+++ b/src/lib/util/internalUtil.ts
@@ -1,5 +1,3 @@
-import { arrayOf } from "./collectionOps.js"
-
 /**
  * Indents a line of text with spaces (2 spaces per indentation level).
  *
@@ -9,6 +7,5 @@ import { arrayOf } from "./collectionOps.js"
  * @internal
  */
 export function indent(line: string, amount: number) {
-  const padding = arrayOf(amount, () => "  ").join("")
-  return padding + line
+  return "  ".repeat(amount) + line
 }

--- a/src/lib/util/noise.ts
+++ b/src/lib/util/noise.ts
@@ -1,4 +1,5 @@
-import { dot } from "./vectors.js";
+import { dot } from "./vectors.js"
+import { Point2D } from "./types.js"
 
 /**
  * 2D Perlin noise implementation.
@@ -17,7 +18,7 @@ import { dot } from "./vectors.js";
  * @internal
  */
 function fade(t: number) {
-  return t * t * t * (t * (t * 6 - 15) + 10);
+  return t * t * t * (t * (t * 6 - 15) + 10)
 }
 
 /**
@@ -30,11 +31,11 @@ function fade(t: number) {
  * @internal
  */
 function lerp(a: number, b: number, t: number) {
-  return (1 - t) * a + t * b;
+  return (1 - t) * a + t * b
 }
 
 /** Gradient vectors for 3D noise (only x,y components used for 2D Perlin noise). */
-const grad3 = [
+const grad3: [number, number, number][] = [
   [1, 1, 0],
   [-1, 1, 0],
   [1, -1, 0],
@@ -46,273 +47,33 @@ const grad3 = [
   [0, 1, 1],
   [0, -1, 1],
   [0, 1, -1],
-  [0, -1, -1]
-];
+  [0, -1, -1],
+]
 
 /** Ken Perlin's original permutation table (256 entries). */
-var p = [
-  151,
-  160,
-  137,
-  91,
-  90,
-  15,
-  131,
-  13,
-  201,
-  95,
-  96,
-  53,
-  194,
-  233,
-  7,
-  225,
-  140,
-  36,
-  103,
-  30,
-  69,
-  142,
-  8,
-  99,
-  37,
-  240,
-  21,
-  10,
-  23,
-  190,
-  6,
-  148,
-  247,
-  120,
-  234,
-  75,
-  0,
-  26,
-  197,
-  62,
-  94,
-  252,
-  219,
-  203,
-  117,
-  35,
-  11,
-  32,
-  57,
-  177,
-  33,
-  88,
-  237,
-  149,
-  56,
-  87,
-  174,
-  20,
-  125,
-  136,
-  171,
-  168,
-  68,
-  175,
-  74,
-  165,
-  71,
-  134,
-  139,
-  48,
-  27,
-  166,
-  77,
-  146,
-  158,
-  231,
-  83,
-  111,
-  229,
-  122,
-  60,
-  211,
-  133,
-  230,
-  220,
-  105,
-  92,
-  41,
-  55,
-  46,
-  245,
-  40,
-  244,
-  102,
-  143,
-  54,
-  65,
-  25,
-  63,
-  161,
-  1,
-  216,
-  80,
-  73,
-  209,
-  76,
-  132,
-  187,
-  208,
-  89,
-  18,
-  169,
-  200,
-  196,
-  135,
-  130,
-  116,
-  188,
-  159,
-  86,
-  164,
-  100,
-  109,
-  198,
-  173,
-  186,
-  3,
-  64,
-  52,
-  217,
-  226,
-  250,
-  124,
-  123,
-  5,
-  202,
-  38,
-  147,
-  118,
-  126,
-  255,
-  82,
-  85,
-  212,
-  207,
-  206,
-  59,
-  227,
-  47,
-  16,
-  58,
-  17,
-  182,
-  189,
-  28,
-  42,
-  223,
-  183,
-  170,
-  213,
-  119,
-  248,
-  152,
-  2,
-  44,
-  154,
-  163,
-  70,
-  221,
-  153,
-  101,
-  155,
-  167,
-  43,
-  172,
-  9,
-  129,
-  22,
-  39,
-  253,
-  19,
-  98,
-  108,
-  110,
-  79,
-  113,
-  224,
-  232,
-  178,
-  185,
-  112,
-  104,
-  218,
-  246,
-  97,
-  228,
-  251,
-  34,
-  242,
-  193,
-  238,
-  210,
-  144,
-  12,
-  191,
-  179,
-  162,
-  241,
-  81,
-  51,
-  145,
-  235,
-  249,
-  14,
-  239,
-  107,
-  49,
-  192,
-  214,
-  31,
-  181,
-  199,
-  106,
-  157,
-  184,
-  84,
-  204,
-  176,
-  115,
-  121,
-  50,
-  45,
-  127,
-  4,
-  150,
-  254,
-  138,
-  236,
-  205,
-  93,
-  222,
-  114,
-  67,
-  29,
-  24,
-  72,
-  243,
-  141,
-  128,
-  195,
-  78,
-  66,
-  215,
-  61,
-  156,
-  180
-];
+const p: number[] = [
+  151, 160, 137, 91, 90, 15, 131, 13, 201, 95, 96, 53, 194, 233, 7, 225, 140,
+  36, 103, 30, 69, 142, 8, 99, 37, 240, 21, 10, 23, 190, 6, 148, 247, 120, 234,
+  75, 0, 26, 197, 62, 94, 252, 219, 203, 117, 35, 11, 32, 57, 177, 33, 88, 237,
+  149, 56, 87, 174, 20, 125, 136, 171, 168, 68, 175, 74, 165, 71, 134, 139, 48,
+  27, 166, 77, 146, 158, 231, 83, 111, 229, 122, 60, 211, 133, 230, 220, 105,
+  92, 41, 55, 46, 245, 40, 244, 102, 143, 54, 65, 25, 63, 161, 1, 216, 80, 73,
+  209, 76, 132, 187, 208, 89, 18, 169, 200, 196, 135, 130, 116, 188, 159, 86,
+  164, 100, 109, 198, 173, 186, 3, 64, 52, 217, 226, 250, 124, 123, 5, 202, 38,
+  147, 118, 126, 255, 82, 85, 212, 207, 206, 59, 227, 47, 16, 58, 17, 182, 189,
+  28, 42, 223, 183, 170, 213, 119, 248, 152, 2, 44, 154, 163, 70, 221, 153, 101,
+  155, 167, 43, 172, 9, 129, 22, 39, 253, 19, 98, 108, 110, 79, 113, 224, 232,
+  178, 185, 112, 104, 218, 246, 97, 228, 251, 34, 242, 193, 238, 210, 144, 12,
+  191, 179, 162, 241, 81, 51, 145, 235, 249, 14, 239, 107, 49, 192, 214, 31,
+  181, 199, 106, 157, 184, 84, 204, 176, 115, 121, 50, 45, 127, 4, 150, 254,
+  138, 236, 205, 93, 222, 114, 67, 29, 24, 72, 243, 141, 128, 195, 78, 66, 215,
+  61, 156, 180,
+]
 
 /** Doubled permutation table (512 entries) for wrapping lookups. */
-const perm = new Array(512);
+const perm: number[] = new Array(512)
 /** Doubled gradient lookup table (512 entries) for wrapping lookups. */
-const gradP = new Array(512);
+const gradP: Point2D[] = new Array(512)
 
 /**
  * Seeds the noise permutation tables using the given seed value.
@@ -325,28 +86,25 @@ const gradP = new Array(512);
  */
 function seedNoise(seed: number) {
   if (seed > 0 && seed < 1) {
-    seed *= 65536;
+    seed *= 65536
   }
 
-  seed = Math.floor(seed);
+  seed = Math.floor(seed)
   if (seed < 256) {
-    seed |= seed << 8;
+    seed |= seed << 8
   }
 
-  for (var i = 0; i < 256; i++) {
-    var v;
-    if (i & 1) {
-      v = p[i] ^ (seed & 255);
-    } else {
-      v = p[i] ^ ((seed >> 8) & 255);
-    }
+  for (let i = 0; i < 256; i++) {
+    const v = i & 1 ? p[i] ^ (seed & 255) : p[i] ^ ((seed >> 8) & 255)
 
-    perm[i] = perm[i + 256] = v;
-    gradP[i] = gradP[i + 256] = grad3[v % 12];
+    perm[i] = perm[i + 256] = v
+    // only the x/y components of the gradient are used for 2D noise
+    const [gX, gY] = grad3[v % 12]
+    gradP[i] = gradP[i + 256] = [gX, gY]
   }
 }
 
-seedNoise(0);
+seedNoise(0)
 
 /**
  * Computes 2D Perlin noise at the given coordinates.
@@ -358,24 +116,24 @@ seedNoise(0);
  * @param ay - The y coordinate
  * @returns The Perlin noise value at `(ax, ay)`
  */
-export function perlin2(ax: number, ay: number) {
-  let X = Math.floor(ax);
-  let Y = Math.floor(ay);
+export function perlin2(ax: number, ay: number): number {
+  let X = Math.floor(ax)
+  let Y = Math.floor(ay)
 
-  let x = ax - X;
-  let y = ay - Y;
+  const x = ax - X
+  const y = ay - Y
 
-  X = X & 255;
-  Y = Y & 255;
+  X = X & 255
+  Y = Y & 255
 
   // Calculate noise contributions from each of the four corners
-  var n00 = dot(gradP[X + perm[Y]], [x, y]);
-  var n01 = dot(gradP[X + perm[Y + 1]], [x, y - 1]);
-  var n10 = dot(gradP[X + 1 + perm[Y]], [x - 1, y]);
-  var n11 = dot(gradP[X + 1 + perm[Y + 1]], [x - 1, y - 1]);
+  const n00 = dot(gradP[X + perm[Y]], [x, y])
+  const n01 = dot(gradP[X + perm[Y + 1]], [x, y - 1])
+  const n10 = dot(gradP[X + 1 + perm[Y]], [x - 1, y])
+  const n11 = dot(gradP[X + 1 + perm[Y + 1]], [x - 1, y - 1])
 
-  const u = fade(x);
+  const u = fade(x)
 
   // Interpolate the four results
-  return lerp(lerp(n00, n10, u), lerp(n01, n11, u), fade(y));
+  return lerp(lerp(n00, n10, u), lerp(n01, n11, u), fade(y))
 }


### PR DESCRIPTION
Removes repeated logic from the drawing library and adds tests for the public methods that had none. Rendered SVG output is unchanged — the existing inline snapshots all still pass untouched.

## Deduplication

| Was | Now |
| --- | --- |
| `image` and `UNSTABLE_imageInkscapeReady` were identical apart from the `mm` suffix, and each inlined the element-walking code that `Group.strings` also contained (3 copies) | one `renderElement` helper, one `render(unit)` |
| Both `imageSrc` variants inlined the same encode/escape logic | `toDataUri(svg, encode)` |
| `forTiling` and `forGrid` each repeated their whole loop body across the `columnFirst`/`rowFirst` branches | `forEachCell(nX, nY, order, visit)` |
| `forHorizontal` and `forVertical` were mirror images of each other | two calls into `forStrips` |
| `path`, `strokedPath`, `filledPath`, `clonePath` shared a push-and-return tail | `addPath` |
| `cutPath` and `creasePath` differed only in stroke lightness | `cutAndFoldPath(lightness, …)` |
| `Attributes.fill` and `.stroke` shared their HSL conversion | private `setHsl` |
| The four-argument iteration callback type was spelled out five times | exported as `RegionCallback` |

## Correctness and type safety

- **Hue wrapping.** `hue2rgb` adjusted its offset with a single `+1`/`-1`, so a hue more than one turn out of range fell through to a flat value. Easy to hit, since incrementing a hue past 360 is a normal thing to do in generative work (`s.sample([h - 20, h, h + 20])`). Now wraps modulo 1, which is identical for in-range input.
- **Invalid hex.** Channel values are now clamped, so out-of-range saturation or lightness can't emit something like `#132132132`.
- **`padZeros`.** Called `.join()` with no separator argument on its padding array — any pad wider than one character would have inserted commas. Only reachable if the two-digit assumption ever changed, but replaced with `padStart` regardless.
- **`Path` end points.** Segments were cast to an unchecked `Toable` type to read `.to`, which silently gives `undefined` after a `close`. Replaced with a discriminated `endPointOf`; a curve in that position now reports what's wrong instead of failing inside the curve maths. The shape helpers (`rect`, `regularPolygon`, `ellipse`, `spiral`) build on `moveTo`/`lineTo` rather than pushing raw segments.
- **`noise.ts`** gave up its types through `new Array(512)`; `perm` and `gradP` are typed and the file uses `const`/`let` throughout.
- `fillOklch`/`strokeOklch` declare `alpha` as optional, matching the `typeof alpha === "number"` guards that were already there.

## Tests

247 → 318. New files cover what was previously untested:

- `svgLayout.test.ts` — `forTiling` (proportionate/square, both orders, margins), `forMargin`, `forHorizontal`, `forVertical`, `forGrid`, `build`, `withRandomOrder`, `range`, `times`, `downFrom`, `doProportion`, `inDrawing`
- `svgRandom.test.ts` — `sample`, `samples`, `shuffle`, `perturb`, `randomPoint`, `randomPolarity`, `randomAngle`, `uniformGridPoint`, plus seed reproducibility of a whole drawing
- `svgOutput.test.ts` — `imageSrc` both encodings, the Inkscape-ready renderings, `groupWithId`, `clonePath` independence, the `filledPath`/`cutPath`/`creasePath` presets
- `noise.test.ts` — `perlin2`, which had no tests: zero at lattice points, determinism, range, continuity, 256-period tiling
- Extended `util.test.ts` for the hue wrapping/clamping/padding fixes, and `path.test.ts` for the segments-without-a-destination cases

`pnpm test`, `pnpm lint`, `pnpm build` and `pnpm verify:package` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_012CB89s9JM7Z5HFUSGxGriQ)_